### PR TITLE
Add therubyracer in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ group :jekyll_plugins do
   gem "jekyll-sitemap"
   gem "octopress-autoprefixer"
 end
+
+# If you want to use GitLab Pages, uncomment the line below.
+# gem "therubyracer", :platforms => :ruby


### PR DESCRIPTION
@thomasvaeth 
If I try to use this theme from GitLab Pages, the following error occurs:

``` bash
$ jekyll build -d public/
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:94:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'octopress-autoprefixer'. (Bundler::GemRequireError)
Gem Load Error is: Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
Backtrace for gem load error is:
/usr/local/bundle/gems/execjs-2.6.0/lib/execjs/runtimes.rb:48:in `autodetect'
/usr/local/bundle/gems/execjs-2.6.0/lib/execjs.rb:5:in `<module:ExecJS>'
/usr/local/bundle/gems/execjs-2.6.0/lib/execjs.rb:4:in `<top (required)>'
/usr/local/bundle/gems/autoprefixer-rails-6.3.6.2/lib/autoprefixer-rails/processor.rb:2:in `require'
/usr/local/bundle/gems/autoprefixer-rails-6.3.6.2/lib/autoprefixer-rails/processor.rb:2:in `<top (required)>'
/usr/local/bundle/gems/autoprefixer-rails-6.3.6.2/lib/autoprefixer-rails.rb:35:in `require_relative'
/usr/local/bundle/gems/autoprefixer-rails-6.3.6.2/lib/autoprefixer-rails.rb:35:in `<top (required)>'
/usr/local/bundle/gems/octopress-autoprefixer-2.0.0/lib/octopress-autoprefixer.rb:2:in `require'
/usr/local/bundle/gems/octopress-autoprefixer-2.0.0/lib/octopress-autoprefixer.rb:2:in `<top (required)>'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:91:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:91:in `block (2 levels) in require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:86:in `each'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:86:in `block in require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:75:in `each'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:75:in `require'
/usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler.rb:106:in `require'
/usr/local/bundle/gems/jekyll-3.1.6/lib/jekyll/plugin_manager.rb:34:in `require_from_bundler'
/usr/local/bundle/gems/jekyll-3.1.6/bin/jekyll:9:in `<top (required)>'
/usr/local/bundle/bin/jekyll:17:in `load'
/usr/local/bundle/bin/jekyll:17:in `<main>'
Bundler Error Backtrace:
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:90:in `block (2 levels) in require'
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:86:in `each'
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:86:in `block in require'
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:75:in `each'
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler/runtime.rb:75:in `require'
    from /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.13.2/lib/bundler.rb:106:in `require'
    from /usr/local/bundle/gems/jekyll-3.1.6/lib/jekyll/plugin_manager.rb:34:in `require_from_bundler'
    from /usr/local/bundle/gems/jekyll-3.1.6/bin/jekyll:9:in `<top (required)>'
    from /usr/local/bundle/bin/jekyll:17:in `load'
    from /usr/local/bundle/bin/jekyll:17:in `<main>'
ERROR: Build failed: exit code 1
```

Adding this line will resolve the problem.
