### PR TITLE
add auto generration for category-files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ social:
 
 # Build settings
 include: ["_categories"]
-exclude: ["_screenshots", "Gemfile", "Gemfile.lock"]
+exclude: ["_screenshots", "Gemfile", "Gemfile.lock", "categories.sh"]
 markdown: kramdown
 permalink: /:year/:month/:day/:title/
 

--- a/categories.sh
+++ b/categories.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+CATS="$(curl "http://127.0.0.1:4000/categories.txt")"
+
+IFS=';' read -ra ADDR <<< "$CATS"
+for i in "${ADDR[@]}"; do
+cat > _categories/${i,,}.html << EOF
+---
+layout: default
+title: "$i"
+description:
+permalink: /category/${i,,}/
+---
+{% include category.html %}
+EOF
+done

--- a/categories.txt
+++ b/categories.txt
@@ -1,0 +1,4 @@
+---
+layout: null
+---
+{% for category in site.categories %}{{ category | first }};{% endfor %}


### PR DESCRIPTION
this little bash-script can be run while the jekyll is running locally. it will then automatically generate the necessary files in the _categories folder automatically
