### PR TITLE
Added page geneator for each category

### DIFF
--- a/_categories/brunch.html
+++ b/_categories/brunch.html
@@ -1,7 +1,0 @@
----
-layout: default
-title: Brunch
-description:
-permalink: /category/brunch/
----
-{% include category.html %}

--- a/_categories/juice.html
+++ b/_categories/juice.html
@@ -1,7 +1,0 @@
----
-layout: default
-title: Juice
-description:
-permalink: /category/juice/
----
-{% include category.html %}

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ social:
   github: 
 
 # Build settings
+category_dir:
 include: ["_categories"]
 exclude: ["_screenshots", "Gemfile", "Gemfile.lock", "LICENSE.txt", "README.md"]
 markdown: kramdown

--- a/_includes/categories-tab.html
+++ b/_includes/categories-tab.html
@@ -8,7 +8,8 @@
 
     {% for category in sortedCats %}
       <li class="card">
-        <a class="card__link" href="{{ site.baseurl }}/category/{{ category | downcase | slugify }}/">
+        {% assign cat_dir = site.category_dir | default: 'category' %}
+        <a class="card__link" href="{{ site.baseurl }}/{{ cat_dir }}/{{ category | downcase | slugify }}/">
           {% for post in site.categories[category] limit: 1 %}
             <div class="card__img">
               {% if post.image-sm %}

--- a/_includes/categories-tab.html
+++ b/_includes/categories-tab.html
@@ -1,10 +1,15 @@
 <div class="tab">
   <ul class="cards">
-    {% for category in site.categories %}
-      {% assign cat_name = category | first %}
+    {% capture cats %}
+      {% for cat in site.categories %}
+        {{ cat | first }}
+      {% endfor %}
+    {% endcapture %}{% assign sortedCats = cats | split:' ' | sort %}
+
+    {% for category in sortedCats %}
       <li class="card">
-        <a class="card__link" href="{{ site.baseurl }}/category/{{ category | first | downcase | slugify }}/">
-          {% for post in site.categories[cat_name] limit: 1 %}
+        <a class="card__link" href="{{ site.baseurl }}/category/{{ category | downcase | slugify }}/">
+          {% for post in site.categories[category] limit: 1 %}
             <div class="card__img">
               {% if post.image-sm %}
                 <figure class="absolute-bg" style="background-image: url('{{ post.image-sm }}');"></figure>
@@ -14,8 +19,8 @@
             </div>
           {% endfor %}
           <div class="card__container">
-            <h2 class="card__header">{{ cat_name }}</h2>
-            <p class="card__count">{{ site.categories[cat_name] | size }} Posts</p>
+            <h2 class="card__header">{{ category }}</h2>
+            <p class="card__count">{{ site.categories[category] | size }} Posts</p>
             <span class="card__more">View All</span>
           </div>
         </a>

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -1,0 +1,4 @@
+---
+layout: default
+---
+{% include category.html %}

--- a/_plugins/category_generator.rb
+++ b/_plugins/category_generator.rb
@@ -1,0 +1,33 @@
+module Jekyll
+
+  class CategoryPage < Page
+    def initialize(site, base, dir, category)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'category_index.html')
+      self.data['category'] = category
+
+      category_title_prefix = site.config['category_title_prefix'] || ''
+      self.data['title'] = "#{category_title_prefix}#{category}"
+    end
+  end
+
+  class CategoryPageGenerator < Generator
+    safe true
+
+    def generate(site)
+      if site.layouts.key? 'category_index'
+        dir = site.config['category_dir'] || 'category'
+        site.categories.each_key do |category|
+          category_dir = File.join(dir, Utils.slugify(category))
+          site.pages << CategoryPage.new(site, site.source, category_dir, category)
+        end
+      end
+    end
+  end
+
+end

--- a/_plugins/category_generator.rb
+++ b/_plugins/category_generator.rb
@@ -10,9 +10,7 @@ module Jekyll
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), 'category_index.html')
       self.data['category'] = category
-
-      category_title_prefix = site.config['category_title_prefix'] || ''
-      self.data['title'] = "#{category_title_prefix}#{category}"
+      self.data['title'] = category
     end
   end
 

--- a/_posts/2016-02-14-bear-family.markdown
+++ b/_posts/2016-02-14-bear-family.markdown
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "Bear family"
+date: 2016-02-14
+categories:
+  - Bear
+  - Animals
+  - Family
+description: 
+image: https://unsplash.it/2000/1200?image=1020
+image-sm: https://unsplash.it/500/300?image=1020
+---
+How beautyful it would be, to enjoy this in real.
+
+This post is not only for showing how the category generator should do it's work, but also, for representing a charming theme.

--- a/_posts/2016-09-07-craft-beer.markdown
+++ b/_posts/2016-09-07-craft-beer.markdown
@@ -4,6 +4,8 @@ title: "Craft Beer"
 date: 2016-09-07
 categories:
   - Juice
+  - Animals
+  - Wood
 description: 
 image: https://unsplash.it/2000/1200?image=1003
 image-sm: https://unsplash.it/500/300?image=1003


### PR DESCRIPTION
Like I've said in #4, but much more forward than #4. A page for each category gets now generated via jekyll on build step.

But: due to the custom plugin, it's not possible anymore to let the repo auto-build via gh-pages. So feel free to merge, or to decline this pull request.

Also sorted the categories in the categories overview.